### PR TITLE
Add functional tests to mean-logger

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
   "license": "MIT",
   "devDependencies": {
     "mocha": "~1.17.1",
-    "should": "~3.1.3"
+    "should": "~3.1.3",
+    "express": "~3.4.8",
+    "mongoose": "~3.8.8",
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
     "mocha": "~1.17.1",
     "should": "~3.1.3",
     "express": "~3.4.8",
-    "mongoose": "~3.8.8",
+    "mongoose": "~3.8.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,5 +16,9 @@
     "log"
   ],
   "author": "Amos Haviv(Linnovate LTD.)",
-  "license": "MIT"
+  "license": "MIT",
+  "devDependencies": {
+    "mocha": "~1.17.1",
+    "should": "~3.1.3"
+  }
 }

--- a/test/mean-logger.test.js
+++ b/test/mean-logger.test.js
@@ -4,19 +4,43 @@ var logger = require('../index');
 var mongoose = require('mongoose');
 var http = require('http');
 
+function fetch(address, done) {
+  var page = [];
+  var req = http.get(address, function(res) { 
+    if (res.statusCode != 200) return done(new Error('Status code ' + res.statusCode));
+    res.setEncoding('utf8');
+    res.on('data', function(ch) { page.push(ch); });
+    res.on('error', function(e) { done(e); });
+    res.on('end', function() {
+      done(null, page.join(''));
+    });
+  });
+  req.on('error', function(e) {
+    done(e);
+  });
+  req.end();
+}
+
+
 describe('mean-logger', function() {
   var app = express();
   var server;
   before(function(done) {
-    var passport = {};
-    
-    logger.init(app, passport, mongoose);
-    app.get('/somepage', function(req, res) {
-      res.json({a: 1, b: 2});
-    });
-    app.use(app.router);
-    server = app.listen(4003, function() {
-      done();
+    mongoose.connect('mongodb://localhost/mean-logger-test', function(err) {
+      if(err) return done(err);
+      mongoose.connection.db.dropCollection('logs', function(err) {
+        if (err) return done(err);
+        var passport = {};
+        
+        logger.init(app, passport, mongoose);
+        app.get('/somepage', function(req, res) {
+          res.json({a: 1, b: 2});
+        });
+        app.use(app.router);
+        server = app.listen(4003, function() {
+          done();
+        });
+      });
     });
   });
 
@@ -25,21 +49,33 @@ describe('mean-logger', function() {
   });
 
   it('does something', function(done) {
-    var page = [];
-    var req = http.get('http://localhost:4003/somepage', function(res) { 
-      res.setEncoding('utf8');
-      res.on('data', function(ch) { page.push(ch); });
-      res.on('error', function(e) { console.log('e=' + e); done(e); });
-      res.on('end', function() {
-        var content = JSON.parse(page.join(''));
-        content.should.eql({a: 1, b: 2});
+    fetch('http://localhost:4003/somepage', function(err, body) {
+      if(err) return done(err);
+      var content = JSON.parse(body);
+      content.should.eql({a: 1, b: 2});
+      done();
+    });
+  });
+  it('is initially empty', function(done) {
+    fetch('http://localhost:4003/logger/show', function(err, body) {
+      if(err) return done(err);
+      var content = JSON.parse(body);
+      content.should.eql([]);
+      done();
+    });
+  });
+  it('items are added via logger/log', function(done) {
+    fetch('http://localhost:4003/logger/log', function(err, body) {
+      if (err) return done(err);
+      fetch('http://localhost:4003/logger/show', function(err, body) {
+        if(err) return done(err);
+        var content = JSON.parse(body);
+        content.should.have.length(1);
+        content[0].should.have.property('__v');
+        content[0].should.have.property('_id');
+        content[0].should.have.property('created');
         done();
       });
     });
-    req.on('error', function(e) {
-      console.log('req.e=' + e.stack);
-      done(e);
-    });
-    req.end();
   });
 });

--- a/test/mean-logger.test.js
+++ b/test/mean-logger.test.js
@@ -56,7 +56,7 @@ describe('mean-logger', function() {
     coll.remove(done);
   });
 
-  it('log is initially empty', function(done) {
+  it('is initially empty', function(done) {
     fetch(port, '/logger/show', function(err, body) {
       if(err) return done(err);
       var content = JSON.parse(body);
@@ -64,7 +64,7 @@ describe('mean-logger', function() {
       done();
     });
   });
-  it('items are added via logger/log', function(done) {
+  it('recrods a new item when /logger/log is accessed', function(done) {
     fetch(port, '/logger/log', function(err, body) {
       if (err) return done(err);
       fetch(port, '/logger/show', function(err, body) {
@@ -74,6 +74,18 @@ describe('mean-logger', function() {
         content[0].should.have.property('__v');
         content[0].should.have.property('_id');
         content[0].should.have.property('created');
+        done();
+      });
+    });
+  });
+  it('takes the log message from the "?msg" query param', function(done) {
+    fetch(port, '/logger/log?msg=some_message', function(err, body) {
+      if (err) return done(err);
+      fetch(port, '/logger/show', function(err, body) {
+        if(err) return done(err);
+        var content = JSON.parse(body);
+        content.should.have.length(1);
+        content[0].should.have.property('message', 'some_message');
         done();
       });
     });

--- a/test/mean-logger.test.js
+++ b/test/mean-logger.test.js
@@ -33,15 +33,12 @@ describe('mean-logger', function() {
       mongoose.connection.db.createCollection('logs', function(err, coll_) {
         if (err) return done(err);
         coll = coll_;
-        coll.remove(function(err) {
-          if (err) return done(err);
-          var passport = {};
-          
-          logger.init(app, passport, mongoose);
-          app.use(app.router);
-          server = app.listen(port, function() {
-            done();
-          });
+
+        var passport = {};
+        logger.init(app, passport, mongoose);
+        app.use(app.router);
+        server = app.listen(port, function() {
+          done();
         });
       });
     });
@@ -53,6 +50,10 @@ describe('mean-logger', function() {
         done(err1 || err2);
       });
     });
+  });
+
+  beforeEach(function(done) {
+    coll.remove(done);
   });
 
   it('log is initially empty', function(done) {

--- a/test/mean-logger.test.js
+++ b/test/mean-logger.test.js
@@ -1,8 +1,45 @@
 var should = require('should');
+var express = require('express');
+var logger = require('../index');
+var mongoose = require('mongoose');
+var http = require('http');
 
-describe('a', function() {
+describe('mean-logger', function() {
+  var app = express();
+  var server;
+  before(function(done) {
+    var passport = {};
+    
+    logger.init(app, passport, mongoose);
+    app.get('/somepage', function(req, res) {
+      res.json({a: 1, b: 2});
+    });
+    app.use(app.router);
+    server = app.listen(4003, function() {
+      done();
+    });
+  });
+
+  after(function(done) {
+    server.close(done);
+  });
+
   it('does something', function(done) {
-    (5).should.be.exactly(5);
-    done();
+    var page = [];
+    var req = http.get('http://localhost:4003/somepage', function(res) { 
+      res.setEncoding('utf8');
+      res.on('data', function(ch) { page.push(ch); });
+      res.on('error', function(e) { console.log('e=' + e); done(e); });
+      res.on('end', function() {
+        var content = JSON.parse(page.join(''));
+        content.should.eql({a: 1, b: 2});
+        done();
+      });
+    });
+    req.on('error', function(e) {
+      console.log('req.e=' + e.stack);
+      done(e);
+    });
+    req.end();
   });
 });

--- a/test/mean-logger.test.js
+++ b/test/mean-logger.test.js
@@ -69,7 +69,16 @@ describe('mean-logger', function() {
       fetchJson(port, '/logger/show', function(err, content) {
         if(err) return done(err);
         content.should.have.length(1);
-        content[0].should.have.property('created');
+        done();
+      });
+    });
+  });
+  it('assigns a creation time to the logged item', function(done) {
+    fetchJson(port, '/logger/log', function(err) {
+      if (err) return done(err);
+      fetchJson(port, '/logger/show', function(err, content) {
+        if(err) return done(err);
+        content.should.have.length(1);
         var date = new Date(content[0].created);
         var now = new Date();
         (now - date).should.be.lessThan(1000 * 60 * 60 * 12); // 12h

--- a/test/mean-logger.test.js
+++ b/test/mean-logger.test.js
@@ -90,4 +90,20 @@ describe('mean-logger', function() {
       });
     });
   });
+  it('shows the logged message in reverse chronological order (recent first)', function(done) {
+    fetch(port, '/logger/log?msg=first', function(err, body) {
+      if (err) return done(err);
+      fetch(port, '/logger/log?msg=second', function(err, body) {
+        if (err) return done(err);
+        fetch(port, '/logger/show', function(err, body) {
+          if(err) return done(err);
+          var content = JSON.parse(body);
+          content.should.have.length(2);
+          content[0].should.have.property('message', 'second');
+          content[1].should.have.property('message', 'first');
+          done();
+        });
+      });
+    });
+  });
 });

--- a/test/mean-logger.test.js
+++ b/test/mean-logger.test.js
@@ -1,0 +1,8 @@
+var should = require('should');
+
+describe('a', function() {
+  it('does something', function(done) {
+    (5).should.be.exactly(5);
+    done();
+  });
+});


### PR DESCRIPTION
This pull-request simply adds a Mocha test to verify the behavior of mean-logger. No changes to mean-logger.js.

Motivation: this is part of a slightly wider effort where I try to improve testability of mean's server.js, which may slightly expand the interface between server.js and mean-logger. Before doing any changes (which will be minimal, and will preserve backward compatibility) I wanted to make sure the current behavior of mean-logger is protected by tests. 
