### PR TITLE
make passport optional

### DIFF
--- a/lib/mean-logger.js
+++ b/lib/mean-logger.js
@@ -94,6 +94,9 @@ Logger.prototype = {
      */
     init: function(app, passport, mongoose) {
         var self = this;
+        
+        // allow for no passport without breaking legacy
+        if (arguments.length == 2) mongoose = passport;
 
         //Checking for valid init 
         if (!app || !passport || !mongoose) {
@@ -124,7 +127,6 @@ Logger.prototype = {
         console.log(message);
         return this;
     }
-}
-
+};
 
 var logger = module.exports = exports = new Logger;

--- a/lib/mean-logger.js
+++ b/lib/mean-logger.js
@@ -129,4 +129,4 @@ Logger.prototype = {
     }
 };
 
-var logger = module.exports = exports = new Logger;
+var logger = module.exports = exports = new Logger();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mean-logger",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "A Logging Module for MEAN Apps.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
It appears that `passport` isn't actually used anywhere in `mean-logger`, so there's really no reason to pass it in. However, we wouldn't want to break legacy code. So, I made `passport` and optional parameter.
